### PR TITLE
Move error check earlier

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -94,7 +94,6 @@ func (l *Logger) log(lvl level, message string, props Properties) error {
 	if l.Async {
 		l.channel <- entry
 	} else {
-
 		seqlog := seqLog{
 			Events: []*event{entry},
 		}

--- a/seq_client.go
+++ b/seq_client.go
@@ -24,13 +24,13 @@ func (sc *seqClient) send(event *seqLog, apiKey string, client *http.Client) err
 
 	request, err := http.NewRequest("POST", fullURL, bytes.NewBuffer(serialized))
 
+	if err != nil {
+		return err
+	}
+
 	if len(apiKey) > 1 {
 		request.Header.Set("X-Seq-ApiKey", apiKey)
 		request.Header.Set("Content-Type", "application/json")
-	}
-
-	if err != nil {
-		return err
 	}
 
 	response, err := client.Do(request)


### PR DESCRIPTION
When the hostname of the Seq URL cannot be resolved, logging caused a `nil` pointer exception.  This is fixed in this PR by checking the error value from `http.NewRequest` before trying to set the header values.